### PR TITLE
Parse - Push Notification Token Tracking

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,3 @@
+export PARSE_APP_ID=''
+export PARSE_APP_KEY=''
+export VERSION=''

--- a/.gitignore
+++ b/.gitignore
@@ -26,3 +26,5 @@ project.xcworkspace
 #
 node_modules/
 npm-debug.log
+
+.env

--- a/index.ios.js
+++ b/index.ios.js
@@ -4,7 +4,7 @@ import regenerator from 'regenerator/runtime';
 import React from 'react-native';
 import Icon from 'FAKIconImage';
 import dedent from 'dedent';
-import {PureRender, Debug} from './decorators';
+import Parse from './parse';
 
 var {
   AlertIOS,
@@ -25,8 +25,13 @@ var {
 // TODO: Bind
 
 class LondonReact extends React.Component {
-  componentWillMount() {
+  async componentWillMount() {
     StatusBarIOS.setStyle('light-content');
+
+    let pushToken = await AsyncStorage.getItem('pushToken');
+    if (pushToken) {
+      await Parse.registerInstallation(pushToken);
+    }
 
     PushNotificationIOS.addEventListener('register', this._savePushToken);
     PushNotificationIOS.addEventListener('notification', this._notificationReceived);
@@ -34,10 +39,10 @@ class LondonReact extends React.Component {
   }
   async _savePushToken(token) {
     await AsyncStorage.setItem('pushToken', token);
-    alert(token);
+    await Parse.registerInstallation(token);
   }
   _notificationReceived(notification) {
-    alert(notification);
+    AlertIOS.alert(notification);
   }
   render() {
     return (

--- a/parse.js
+++ b/parse.js
@@ -1,0 +1,21 @@
+export default class Parse {
+  static async registerInstallation(deviceToken) {
+      let payload = {
+        method: 'post',
+        headers: {
+          'Accept': 'application/json',
+          'Content-Type': 'application/json',
+          'X-Parse-Application-Id': process.env.PARSE_APP_ID,
+          'X-Parse-REST-API-Key': process.env.PARSE_APP_KEY
+        },
+        body: JSON.stringify({
+          'appName': 'London React',
+          'appVersion': process.env.VERSION,
+          'deviceType': 'ios',
+          'deviceToken': deviceToken
+        })
+      };
+
+      return await fetch('https://api.parse.com/1/installations', payload);
+  }
+}


### PR DESCRIPTION
Track the `pushToken` returned after iOS permission is granted for Push Notifiations.
