### PR TITLE
Bugsnag for React Native

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,3 +1,4 @@
 export PARSE_APP_ID=''
 export PARSE_APP_KEY=''
 export VERSION=''
+export BUGSNAG_KEY=''

--- a/bugsnag-native.js
+++ b/bugsnag-native.js
@@ -1,0 +1,75 @@
+export default class Bugsnag {
+  static notify(error) {
+    fetch('https://notify.bugsnag.com/', {
+      method: 'post',
+      headers: {
+        'Accept': 'application/json',
+        'Content-Type': 'application/json',
+      },
+      body: JSON.stringify(this._build(error))
+    }).then(console.log).catch(console.log);
+  }
+  static _build(error) {
+    return {
+      apiKey: process.env.BUGSNAG_KEY,
+      notifier: {
+        name: 'React Native',
+        version: '1.0.11',
+        url: 'https://github.com/bugsnag/bugsnag-ruby'
+      },
+      events: [{
+        payloadVersion: '2',
+        exceptions: [{
+          errorClass: error.constructor.name || error.name || 'Error',
+          message: error.message,
+          stacktrace: this._processStackTrace(error)
+        }],
+        context: 'auth/session#create',
+        severity: 'error',
+        user: {
+          id: '19',
+          name: 'Simon Maynard',
+          email: 'simon@bugsnag.com'
+        },
+        app: {
+          version: '1.1.3',
+          releaseStage: 'production',
+        },
+
+        device: {
+          osVersion: '2.1.1',
+          hostname: 'web1.internal'
+        },
+
+        metaData: {
+          someData: {
+            key: 'value',
+            setOfKeys: {
+              key: 'value',
+              key2: 'value'
+            }
+          },
+        }
+      }]
+    };
+  }
+  static _processStackTrace(error) {
+    return [{
+      file: 'controllers/auth/session_controller.rb',
+      lineNumber: 1234,
+      columnNumber: 123,
+      method: 'create',
+      inProject: true,
+    }];
+
+    let blah = stacktrace.parse(error);
+    return callSites.map(function(callSite) {
+      return {
+         file: callSite.getFileName(),
+         method: callSite.getMethodName() || callSite.getFunctionName() || 'none',
+         lineNumber: callSite.getLineNumber(),
+         columnNumber: callSite.getColumnNumber()
+      };
+    });
+  }
+}

--- a/index.ios.js
+++ b/index.ios.js
@@ -1,5 +1,6 @@
 /* @flow */
 
+import bugsnag from './bugsnag-native';
 import regenerator from 'regenerator/runtime';
 import React from 'react-native';
 import Icon from 'FAKIconImage';
@@ -20,6 +21,8 @@ var {
   TouchableOpacity,
   View
 } = React;
+
+ErrorUtils.setGlobalHandler(error => bugsnag.notify(error));
 
 // TODO: Bind
 


### PR DESCRIPTION
Adds support for Error reporting via Bugsnag. Uses the REST API directly, as neither the Node.js build or the browser build work properly under the JSCore environment without heavy modification.
